### PR TITLE
remove every-minute cron job to test emailer

### DIFF
--- a/server/init/startCronJobs.ts
+++ b/server/init/startCronJobs.ts
@@ -4,7 +4,4 @@ import emailSiteSummary from '../summary/emailSiteSummary';
 export default async function startCronJobs() {
   const siteSummaryEmailJob = new CronJob('1 0 * * *', emailSiteSummary);
   siteSummaryEmailJob.start();
-
-  const rapidEmailCron = new CronJob('* * * * *', emailSiteSummary);
-  rapidEmailCron.start();
 }


### PR DESCRIPTION
In order to test the nightly email with site data, I added a cron job that runs every minute. Since that is **NOT** a good thing for my inbox longterm, I am removing the job since I know that the monitoring now works.